### PR TITLE
feat: Add consolidated KPI endpoint and CSV logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,6 +32,15 @@ except ImportError as e:
     logging.critical(f"CRITICAL ERROR: Failed to import perform_daily_data_update from financial_tracker.py: {e}. API endpoint will not function correctly.")
     perform_daily_data_update = None
 
+# Import KPI fetching and saving functions
+try:
+    from metrics_fetcher import get_consolidated_kpi_data, save_kpi_data_to_csv
+    logging.info("Successfully imported KPI functions from metrics_fetcher.py")
+except ImportError as e:
+    logging.critical(f"CRITICAL ERROR: Failed to import from metrics_fetcher.py: {e}. KPI endpoint will not function correctly.")
+    get_consolidated_kpi_data = None
+    save_kpi_data_to_csv = None
+
 
 # Initialize FastAPI app
 app_fastapi = FastAPI(title="Financial Metrics API & Dashboard")
@@ -76,6 +85,55 @@ async def api_trigger_update_data(request: Request):
     except Exception as e:
         logging.exception("Unhandled exception during API-triggered data update (FastAPI):")
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred during data update: {str(e)}")
+
+# --- New KPI Endpoint ---
+@app_fastapi.get("/api/consolidated-kpi")
+async def get_consolidated_kpi():
+    """
+    Provides consolidated KPI data.
+    Fetches data using get_consolidated_kpi_data, saves it to CSV, and returns the data.
+    """
+    logging.info("Endpoint /api/consolidated-kpi execution started.")
+
+    if not get_consolidated_kpi_data or not save_kpi_data_to_csv:
+        logging.error("SERVER ERROR: KPI functions (get_consolidated_kpi_data or save_kpi_data_to_csv) not available due to import failure.")
+        raise HTTPException(status_code=500, detail="Server error: KPI processing functions are not available. Check server logs.")
+
+    try:
+        # 1. Fetch KPI data
+        kpi_data = get_consolidated_kpi_data() # This is a synchronous function
+
+        # 2. Check for errors during fetching (already logged by metrics_fetcher)
+        if not kpi_data: # Should not happen if get_consolidated_kpi_data always returns a dict
+            logging.error("get_consolidated_kpi_data returned None or empty. This should not happen.")
+            # Still attempt to save, as save_kpi_data_to_csv handles empty dicts.
+            # And return an appropriate response.
+            kpi_data = {"error": "Failed to fetch any KPI data or data was empty."} # Ensure kpi_data is a dict
+
+        if "mstr_kpi_error" in kpi_data or "bitcoin_kpi_error" in kpi_data:
+            logging.warning(f"Fetched KPI data contains error indicators: MSTR error: {kpi_data.get('mstr_kpi_error')}, Bitcoin error: {kpi_data.get('bitcoin_kpi_error')}")
+            # Proceed to save and return whatever was fetched
+
+        # 3. Save data to CSV
+        try:
+            # save_kpi_data_to_csv is synchronous
+            save_kpi_data_to_csv(kpi_data)
+            logging.info("Successfully attempted to save KPI data to CSV.")
+        except Exception as csve:
+            # Log the error but don't let it stop the API from returning fetched data
+            logging.exception(f"Error saving KPI data to CSV: {csve}")
+            # Optionally, add a note to the response:
+            # kpi_data["csv_save_error"] = str(csve) # This would alter the response based on save status.
+                                                 # For now, requirement is to return fetched data regardless.
+
+        logging.info("Endpoint /api/consolidated-kpi execution finished successfully.")
+        return kpi_data # FastAPI serializes dict to JSON
+
+    except HTTPException:
+        raise # Re-raise HTTPException directly if it's one we've thrown (like the 500 for import issues)
+    except Exception as e:
+        logging.exception("Unhandled exception in /api/consolidated-kpi endpoint:")
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred while processing KPI data: {str(e)}")
 
 # --- Mount Dash App ---
 # This makes the Dash app accessible under the FastAPI application.

--- a/main.py
+++ b/main.py
@@ -41,9 +41,96 @@ except ImportError as e:
     get_consolidated_kpi_data = None
     save_kpi_data_to_csv = None
 
+# Import for APScheduler
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+try:
+    from metrics_fetcher import fetch_and_save_kpi_data_job
+    logging.info("Successfully imported fetch_and_save_kpi_data_job from metrics_fetcher.py for scheduling.")
+except ImportError as e:
+    logging.critical(f"CRITICAL ERROR: Failed to import fetch_and_save_kpi_data_job from metrics_fetcher.py: {e}. Scheduled job will not be configured.")
+    fetch_and_save_kpi_data_job = None
+
+from datetime import datetime, timedelta, timezone # For scheduler job run_date
+
+# Initialize the scheduler instance
+scheduler = AsyncIOScheduler()
 
 # Initialize FastAPI app
 app_fastapi = FastAPI(title="Financial Metrics API & Dashboard")
+
+# --- Scheduler Lifecycle Events ---
+@app_fastapi.on_event("startup")
+async def start_scheduler():
+    if N_HOURLY_FETCH > 0 and fetch_and_save_kpi_data_job is not None:
+        logging.info(f"Configuring and starting APScheduler to run job every {N_HOURLY_FETCH} hours.")
+        try:
+            # Schedule the job to run at intervals
+            scheduler.add_job(
+                fetch_and_save_kpi_data_job,
+                'interval',
+                hours=N_HOURLY_FETCH,
+                id="interval_kpi_fetch_job",
+                replace_existing=True
+            )
+            # Schedule the job to run once shortly after startup
+            # This ensures data is fetched soon after deployment/restart
+            scheduler.add_job(
+                fetch_and_save_kpi_data_job,
+                trigger='date', # Specifies a single run
+                run_date=datetime.now(timezone.utc) + timedelta(seconds=10), # Run 10 seconds from now
+                id="startup_kpi_fetch_job",
+                replace_existing=True
+            )
+            scheduler.start()
+            logging.info("APScheduler started successfully with KPI data fetch job.")
+        except Exception as e:
+            logging.exception(f"Error starting APScheduler or adding jobs: {e}")
+    else:
+        if fetch_and_save_kpi_data_job is None:
+            logging.warning("Scheduler not starting because fetch_and_save_kpi_data_job could not be imported.")
+        else:
+            logging.info(f"Scheduler not starting due to N_HOURLY_FETCH configuration (value: {N_HOURLY_FETCH}).")
+
+@app_fastapi.on_event("shutdown")
+async def shutdown_scheduler():
+    if scheduler.running:
+        logging.info("APScheduler is running. Attempting to shut down.")
+        try:
+            scheduler.shutdown()
+            logging.info("APScheduler shut down successfully.")
+        except Exception as e:
+            logging.exception(f"Error shutting down APScheduler: {e}")
+    else:
+        logging.info("APScheduler was not running. No shutdown needed.")
+
+
+# --- Scheduler Configuration ---
+# Read N_HOURLY_FETCH environment variable to configure scheduler
+N_HOURLY_FETCH_STR = os.environ.get('N_HOURLY_FETCH')
+N_HOURLY_FETCH = -1  # Default to -1 (do not run scheduler)
+
+if N_HOURLY_FETCH_STR:
+    try:
+        N_HOURLY_FETCH = int(N_HOURLY_FETCH_STR)
+        if N_HOURLY_FETCH == 0: # Treat 0 as "do not run" similar to -1 or invalid
+            N_HOURLY_FETCH = -1
+            logging.info("N_HOURLY_FETCH environment variable is 0, scheduler will not run.")
+        elif N_HOURLY_FETCH < -1: # Treat any other negative as "do not run"
+            N_HOURLY_FETCH = -1
+            logging.info(f"N_HOURLY_FETCH environment variable is {N_HOURLY_FETCH_STR} (negative, not -1), scheduler will not run.")
+        elif N_HOURLY_FETCH > 0:
+            logging.info(f"N_HOURLY_FETCH set to {N_HOURLY_FETCH} hours. Scheduler will be configured.")
+        # If N_HOURLY_FETCH remains -1 (from default or explicit -1 value passed in env), it means don't run.
+        # An explicit value of -1 in env means "do not run".
+        elif N_HOURLY_FETCH == -1:
+             logging.info("N_HOURLY_FETCH environment variable is -1, scheduler will not run.")
+
+    except ValueError:
+        logging.warning(f"Invalid value for N_HOURLY_FETCH: '{N_HOURLY_FETCH_STR}'. Must be an integer. Scheduler will not run.")
+        N_HOURLY_FETCH = -1 # Ensure it's -1 on error
+else:
+    logging.info("N_HOURLY_FETCH environment variable not set. Scheduler will not run.")
+
 
 # --- API Endpoint Definition ---
 @app_fastapi.post("/api/update-data", status_code=204)

--- a/metrics_fetcher.py
+++ b/metrics_fetcher.py
@@ -1,0 +1,119 @@
+import requests
+import json
+import logging
+from datetime import datetime
+import csv
+import os
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Define constants for the URLs
+MSTR_KPI_URL = "https://api.microstrategy.com/btc/mstrKpiData"
+BITCOIN_KPI_URL = "https://api.microstrategy.com/btc/bitcoinKpis"
+CSV_FILENAME = "consolidated_kpi_history.csv"
+
+def get_consolidated_kpi_data():
+    """
+    Fetches KPI data from MSTR and Bitcoin APIs, consolidates them, and adds a timestamp.
+
+    Returns:
+        A dictionary containing the consolidated KPI data.
+    """
+    consolidated_data = {}
+
+    # Fetch data from MSTR_KPI_URL
+    try:
+        response_mstr = requests.get(MSTR_KPI_URL)
+        response_mstr.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+        mstr_kpi_data = response_mstr.json()
+        consolidated_data.update(mstr_kpi_data)
+        logging.info(f"Successfully fetched MSTR KPI data from {MSTR_KPI_URL}")
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Error fetching MSTR KPI data from {MSTR_KPI_URL}: {e}")
+        consolidated_data["mstr_kpi_error"] = f"Failed to fetch data: {e}"
+    except json.JSONDecodeError as e:
+        logging.error(f"Error decoding JSON response from {MSTR_KPI_URL}: {e}")
+        consolidated_data["mstr_kpi_error"] = f"Failed to parse JSON data: {e}"
+
+    # Fetch data from BITCOIN_KPI_URL
+    try:
+        response_bitcoin = requests.get(BITCOIN_KPI_URL)
+        response_bitcoin.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+        bitcoin_kpi_data = response_bitcoin.json()
+        # Simple update; if key clashes occur, Bitcoin data will overwrite MSTR data for that key.
+        # Consider prefixing keys if necessary, e.g., {'bitcoin_marketCap': value}
+        consolidated_data.update(bitcoin_kpi_data)
+        logging.info(f"Successfully fetched Bitcoin KPI data from {BITCOIN_KPI_URL}")
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Error fetching Bitcoin KPI data from {BITCOIN_KPI_URL}: {e}")
+        consolidated_data["bitcoin_kpi_error"] = f"Failed to fetch data: {e}"
+    except json.JSONDecodeError as e:
+        logging.error(f"Error decoding JSON response from {BITCOIN_KPI_URL}: {e}")
+        consolidated_data["bitcoin_kpi_error"] = f"Failed to parse JSON data: {e}"
+
+    # Add timestamp
+    consolidated_data['timestamp'] = datetime.utcnow().isoformat()
+
+    return consolidated_data
+
+def save_kpi_data_to_csv(data_dict):
+    """
+    Saves the given data dictionary to a CSV file.
+    Appends data if the file exists, otherwise creates a new file with headers.
+
+    Args:
+        data_dict: A dictionary containing the data to save.
+    """
+    if not data_dict:
+        logging.warning("No data provided to save_kpi_data_to_csv. Skipping.")
+        return
+
+    file_exists = os.path.exists(CSV_FILENAME)
+    # It's also good practice to check if the file is empty even if it exists
+    is_empty_file = False
+    if file_exists:
+        is_empty_file = os.path.getsize(CSV_FILENAME) == 0
+
+    try:
+        with open(CSV_FILENAME, 'a', newline='') as csvfile:
+            # Ensure all potential keys are included in fieldnames
+            # This might need adjustment if data_dict structure varies significantly
+            # For now, using keys from the current data_dict
+            fieldnames = list(data_dict.keys())
+
+            # Ensure 'timestamp' is a field, and perhaps make it the first column for consistency
+            if 'timestamp' not in fieldnames and any(data_dict.values()):
+                # This case should ideally not happen if get_consolidated_kpi_data always adds it
+                # and data_dict is not empty.
+                logging.warning("Timestamp missing in non-empty data_dict, adding current time.")
+                data_dict['timestamp'] = datetime.utcnow().isoformat()
+                fieldnames.append('timestamp')
+
+            # Reorder fieldnames to have 'timestamp' first if it exists and was added.
+            # This also handles the case where timestamp was already there.
+            if 'timestamp' in fieldnames:
+                fieldnames.remove('timestamp')
+                fieldnames.insert(0, 'timestamp')
+            else:
+                # If timestamp was not in keys and data_dict was empty or all Nones,
+                # it wouldn't have been added. Add it now to ensure it's a column.
+                # This ensures the timestamp column is created even for an empty data record,
+                # though get_consolidated_kpi_data should prevent totally empty dicts.
+                if not any(data_dict.values()): # If dict is empty or all values are None/False/0
+                    data_dict['timestamp'] = datetime.utcnow().isoformat()
+                fieldnames.insert(0, 'timestamp')
+
+
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames, extrasaction='ignore')
+
+            if not file_exists or is_empty_file:
+                writer.writeheader()
+                logging.info(f"Writing CSV header to {CSV_FILENAME}")
+
+            writer.writerow(data_dict)
+            logging.info(f"Successfully wrote data to {CSV_FILENAME}")
+    except IOError as e:
+        logging.error(f"Error writing to CSV file {CSV_FILENAME}: {e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred during CSV writing: {e}")

--- a/metrics_fetcher.py
+++ b/metrics_fetcher.py
@@ -117,3 +117,25 @@ def save_kpi_data_to_csv(data_dict):
         logging.error(f"Error writing to CSV file {CSV_FILENAME}: {e}")
     except Exception as e:
         logging.error(f"An unexpected error occurred during CSV writing: {e}")
+
+async def fetch_and_save_kpi_data_job():
+    """
+    Scheduled job to fetch consolidated KPI data and save it to a CSV file.
+    This function is intended to be called by a scheduler (e.g., APScheduler).
+    It calls synchronous functions get_consolidated_kpi_data and save_kpi_data_to_csv.
+    """
+    logging.info("Scheduled job 'fetch_and_save_kpi_data_job' started.")
+    try:
+        # Call the synchronous function to get data.
+        # If using AsyncIOScheduler, it will run this in a thread pool.
+        data = get_consolidated_kpi_data()
+
+        if data:
+            # Call the synchronous function to save data.
+            save_kpi_data_to_csv(data)
+            logging.info("Scheduled job 'fetch_and_save_kpi_data_job' completed successfully.")
+        else:
+            logging.warning("Scheduled job 'fetch_and_save_kpi_data_job': No data returned by get_consolidated_kpi_data. Nothing to save.")
+
+    except Exception as e:
+        logging.exception("Scheduled job 'fetch_and_save_kpi_data_job' failed.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ html5lib
 dash
 fastapi
 uvicorn[standard]
+apscheduler


### PR DESCRIPTION
This commit introduces a new GET endpoint `/api/consolidated-kpi`.

The endpoint performs the following actions:
1. Fetches data from two MicroStrategy API endpoints:
   - `https://api.microstrategy.com/btc/mstrKpiData`
   - `https://api.microstrategy.com/btc/bitcoinKpis`
2. Consolidates the data from these two sources into a single JSON object.
3. Adds a UTC timestamp to the consolidated data.
4. Appends the consolidated data as a new row to a CSV file named `consolidated_kpi_history.csv`. This file is created if it doesn't exist, and headers are written automatically.
5. Returns the consolidated JSON object as the API response.

The logic for fetching, consolidating, and saving to CSV is encapsulated in a new file, `metrics_fetcher.py`, to maintain code organization. Robust error handling and logging are implemented throughout the process.